### PR TITLE
Encode search query with 'encodeURIComponent' instead of 'encodeURI' …

### DIFF
--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -9,7 +9,9 @@ export async function searchVideo(searchQuery: string) {
   let fetched = false;
   const options = { type: "video", limit: 0 };
 
-  const searchRes: any = await got.get(encodeURI(`${YOUTUBE_URL}/results?q=${encodeURIComponent(searchQuery.trim())}&hl=en`));
+  const rfc3986EncodeURIComponent = (str: string) => encodeURIComponent(str).replace(/[!'()*]/g, escape);
+
+  const searchRes: any = await got.get(`${YOUTUBE_URL}/results?q=${rfc3986EncodeURIComponent(searchQuery.trim())}&hl=en`);
   let html = await searchRes.body;
   // try to parse html
   try {

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -9,7 +9,7 @@ export async function searchVideo(searchQuery: string) {
   let fetched = false;
   const options = { type: "video", limit: 0 };
 
-  const searchRes: any = await got.get(encodeURI(`${YOUTUBE_URL}/results?q=${encodeURI(searchQuery.trim())}&hl=en`));
+  const searchRes: any = await got.get(encodeURI(`${YOUTUBE_URL}/results?q=${encodeURIComponent(searchQuery.trim())}&hl=en`));
   let html = await searchRes.body;
   // try to parse html
   try {


### PR DESCRIPTION
…because 'encodeURI' does not encode commas

See: https://developers.google.com/maps/url-encoding

Example: When searching YT manually for `Marsh, Guy J Healer Guy J Extended Mix` the `search_query` is encoded as `Marsh%2C+Guy+J+Healer+Guy+J+Extended+Mix`

The output of `encodeURI('Marsh, Guy J Healer Guy J Extended Mix')` is `Marsh,%20Guy%20J%20Healer%20Guy%20J%20Extended%20Mix`, which when set as the `search_query`, returns very inaccurate results.

The output of `encodeURIComponent` is `Marsh%2C%20Guy%20J%20Healer%20Guy%20J%20Extended%20Mix` and returns the correct results.

Thank you!
