### PR TITLE
feat: add author property

### DIFF
--- a/src/lib/parser.service.ts
+++ b/src/lib/parser.service.ts
@@ -17,6 +17,7 @@ export class ParserService {
           videoId: data.videoRenderer.videoId
         },
         url: `https://www.youtube.com/watch?v=${data.videoRenderer.videoId}`,
+        author: data.videoRenderer.ownerText.runs[0].text,
         title,
         description: data.videoRenderer.descriptionSnippet && data.videoRenderer.descriptionSnippet.runs[0] ? data.videoRenderer.descriptionSnippet.runs[0].text : "",
         duration_raw: data.videoRenderer.lengthText ? data.videoRenderer.lengthText.simpleText : null,


### PR DESCRIPTION
This PR adds a new author property in the return object of ParserService, making yt.search() can also find out the author of the video.